### PR TITLE
Add placeholder TFLite example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # OCR2
+
+This repository contains an example of using a TensorFlow Lite (TFLite) model.
+
+## Usage
+1. Copy your `.tflite` model file to the `models` directory with the name `model.tflite`.
+2. Install the required dependencies:
+   ```bash
+   pip install tensorflow
+   ```
+3. Run the inference script:
+   ```bash
+   python run_inference.py
+   ```
+
+The script will load `models/model.tflite`, run a dummy inference with zeros, and print the output.

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,3 @@
+This directory is intended to hold your TensorFlow Lite model file.
+
+Place your `model.tflite` file here so that `run_inference.py` can load it.

--- a/run_inference.py
+++ b/run_inference.py
@@ -1,0 +1,26 @@
+import numpy as np
+import tensorflow as tf
+
+MODEL_PATH = 'models/model.tflite'
+
+def load_model(path=MODEL_PATH):
+    interpreter = tf.lite.Interpreter(model_path=path)
+    interpreter.allocate_tensors()
+    return interpreter
+
+def run_dummy_inference(interpreter):
+    input_details = interpreter.get_input_details()
+    output_details = interpreter.get_output_details()
+
+    input_shape = input_details[0]['shape']
+    dummy_input = np.zeros(input_shape, dtype=np.float32)
+    interpreter.set_tensor(input_details[0]['index'], dummy_input)
+
+    interpreter.invoke()
+    output_data = interpreter.get_tensor(output_details[0]['index'])
+    return output_data
+
+if __name__ == '__main__':
+    interp = load_model()
+    result = run_dummy_inference(interp)
+    print('Output:', result)


### PR DESCRIPTION
## Summary
- add README usage instructions
- add run_inference.py to demonstrate loading a TFLite model
- add models directory with README

## Testing
- `pip install numpy tensorflow --quiet`
- `python3 run_inference.py` *(fails: ValueError: Could not open 'models/model.tflite')*

------
https://chatgpt.com/codex/tasks/task_e_6841f76df670832f8d36799111e5f86e