### PR TITLE
Fix dependency version in build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'com.android.application'
+}
+
+android {
+    compileSdk 34
+    defaultConfig {
+        applicationId 'com.example.ocr2'
+        minSdk 21
+        targetSdk 34
+        versionCode 1
+        versionName '1.0'
+    }
+}
+
+dependencies {
+    implementation 'com.google.android.gms:play-services-mlkit-text-recognition:19.0.1'
+}


### PR DESCRIPTION
## Summary
- add minimal app module build.gradle
- use `play-services-mlkit-text-recognition:19.0.1`

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6841fb844ef4832f81a3c1625e6d3657